### PR TITLE
Debuff duration fix

### DIFF
--- a/Addons/WeakAuras/ActionButtonData.lua
+++ b/Addons/WeakAuras/ActionButtonData.lua
@@ -125,5 +125,5 @@ function ABD_MainStanceBars(profile)
 end
 
 function ABD_SlotNumber(slotId)
-	return math.mod(slotId - 1, 12) + 1;
+	return math.fmod(slotId - 1, 12) + 1;
 end

--- a/Addons/WeakAuras/RegionTypes/icon.lua
+++ b/Addons/WeakAuras/RegionTypes/icon.lua
@@ -321,6 +321,10 @@ local function modify(parent, region, data)
     end
     
     local function UpdateDurationInfo(duration, expirationTime, customValue)
+        if(duration == nil) then
+            duration = 0
+        end
+
         if(duration <= 0.01 or duration > region.duration or not data.stickyDuration) then
             region.duration = duration;
         end

--- a/Addons/WeakAuras/RegionTypes/progresstexture.lua
+++ b/Addons/WeakAuras/RegionTypes/progresstexture.lua
@@ -409,6 +409,10 @@ local function modify(parent, region, data)
     end
     
     function region:SetDurationInfo(duration, expirationTime, customValue, inverse)
+        if(duration == nil) then
+            duration = 0
+        end
+
         if(duration <= 0.01 or duration > region.duration or not data.stickyDuration) then
             region.duration = duration;
         end

--- a/Addons/WeakAuras/libs/Backport/Backport.lua
+++ b/Addons/WeakAuras/libs/Backport/Backport.lua
@@ -87,7 +87,7 @@ function UnitAura (unit, indexOrName, rank, filter)
   end
 
   if (debuffType == "HARMFUL" or debuffType == nil) then
-    local name, r, icon, count, duration, expirationTime = UnitDebuff(unit, 1, newfilter);
+    local name, r, icon, count, _, duration, expirationTime = UnitDebuff(unit, 1, newfilter);
     x = 1;
     while (name ~= nil) do
       if (name == indexOrName and (rank == nil or string.find(rank, "HARMFUL") or string.find(rank, "HELPFUL") or rank == r)) then


### PR DESCRIPTION
Fixed:
- use fmod instead of mod
- if duration is passed to UpdateDurationInfo as a nil value it is set to 0 (texture and icon)
- correctly save duration and expiration timer for debuffs (see UnitDebuff API)